### PR TITLE
Apply syntax to preview

### DIFF
--- a/denops/@ddu-kinds/help.ts
+++ b/denops/@ddu-kinds/help.ts
@@ -48,6 +48,7 @@ export class Kind extends BaseKind<Params> {
       kind: "buffer",
       path: action.path,
       pattern: action.pattern,
+      syntax: "help",
     });
   }
 


### PR DESCRIPTION
プレビューの際のシンタックスの自動検出はhelpに対して働かないので明示的に指定するようにします