### PR TITLE
Fix regexp

### DIFF
--- a/denops/@ddu-sources/help.ts
+++ b/denops/@ddu-sources/help.ts
@@ -43,7 +43,7 @@ export class Source extends BaseSource<Params> {
               if (langs.includes(m[1])) {
                 helpMap[m[1]].push(f);
               }
-            } else if (/doc(:?\/|\\)tags$/.test(f)) {
+            } else if (/doc[\/\\]tags$/.test(f)) {
               helpMap["en"].push(f);
             }
           }


### PR DESCRIPTION
I think `(:?)` is a mistake for `(?:)`.
And the character class is more concise if you just want to indicate `/` or `\`.
