### PR TITLE
Fix: can't collect english tags when missing `'helptags'`

### DIFF
--- a/denops/@ddu-sources/help.ts
+++ b/denops/@ddu-sources/help.ts
@@ -25,9 +25,12 @@ export class Source extends BaseSource<Params> {
       async start(controller) {
         const langs = args.sourceParams.helpLang?.split(",") ??
           (await op.helplang.getGlobal(args.denops)).split(",");
+        if (!langs.includes("en")) {
+          langs.push("en");
+        }
         const helpMap: Record<string, string[]> = langs.reduce(
           (acc, lang) => ({ ...acc, [lang]: [] }),
-          { en: [] },
+          {},
         );
 
         try {


### PR DESCRIPTION
Fix tag collect behavior since https://github.com/matsui54/ddu-source-help/commit/319008f7abfda4893231cae82f49d328164ebdc9