### PR TITLE
Update ddu-kind-help to add command history feature

### DIFF
--- a/denops/@ddu-kinds/help.ts
+++ b/denops/@ddu-kinds/help.ts
@@ -5,7 +5,6 @@ import {
   DduItem,
   Previewer,
 } from "https://deno.land/x/ddu_vim@v3.0.2/types.ts";
-import { Denops } from "https://deno.land/x/ddu_vim@v3.0.2/deps.ts";
 
 export type ActionData = {
   word: string;
@@ -17,7 +16,9 @@ type OpenParams = {
   command: string;
 };
 
-type Params = Record<never, never>;
+type Params = {
+  histadd?: boolean;
+};
 
 export class Kind extends BaseKind<Params> {
   actions: Record<
@@ -28,6 +29,7 @@ export class Kind extends BaseKind<Params> {
       denops,
       actionParams,
       items,
+      kindParams,
     }: ActionArguments<Params>) => {
       const params = actionParams as OpenParams;
       // Convert sp[lit], vs[plit] tabe[dit] -> "vertical", "", "tab"
@@ -43,7 +45,13 @@ export class Kind extends BaseKind<Params> {
       );
 
       const action = items[0]?.action as ActionData;
-      await denops.cmd(`silent ${openCommand} help ${action.word}`);
+      const command = `${openCommand} help ${action.word}`;
+
+      if (kindParams.histadd) {
+        await denops.call("histadd", "cmd", command.replace(/^\s+/, ""));
+      }
+
+      await denops.cmd(`silent! ${command}`);
       return Promise.resolve(ActionFlags.None);
     },
     vsplit: (args: ActionArguments<Params>) => {

--- a/denops/@ddu-kinds/help.ts
+++ b/denops/@ddu-kinds/help.ts
@@ -17,7 +17,7 @@ type OpenParams = {
 };
 
 type Params = {
-  histadd?: boolean;
+  histadd: boolean;
 };
 
 export class Kind extends BaseKind<Params> {
@@ -84,6 +84,8 @@ export class Kind extends BaseKind<Params> {
   }
 
   params(): Params {
-    return {};
+    return {
+      histadd: false,
+    };
   }
 }

--- a/doc/ddu-source-help.txt
+++ b/doc/ddu-source-help.txt
@@ -80,4 +80,13 @@ tabopen
 		Open help in a new tab.
 
 ==============================================================================
+
+KIND PARAMS						*ddu-kind-help-params*
+
+						*ddu-kind-help-params-histadd*
+histadd		(boolean)
+		Add cmdline history.
+
+		Default: false
+
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
In this commit, the `denops/@ddu-kinds/help.ts` file has been modified to support the addition of command history. This is controlled by the new `histadd` parameter introduced in this update. If it is set to `true`, the command will be added to the Vim command line history.

This change is reflected in the updated documentation in `doc/ddu-source-help.txt`, where a new section `KIND PARAMS` has been added to describe the new `histadd` parameter.

This feature improves usability by allowing users to revisit previous commands directly from the Vim command line history, rather than having to type them in again.
