### PR TITLE
Ignored even if 'tags' is specified in 'wildignore'

### DIFF
--- a/denops/@ddu-sources/help.ts
+++ b/denops/@ddu-sources/help.ts
@@ -36,7 +36,7 @@ export class Source extends BaseSource<Params> {
         try {
           const rtp = await op.runtimepath.getGlobal(args.denops);
           const tagfiles = (
-            await fn.globpath(args.denops, rtp, "doc/tags*")
+            await fn.globpath(args.denops, rtp, "doc/tags*", true)
           ).split("\n");
 
           for (const f of tagfiles) {


### PR DESCRIPTION
Because ‘tags’ is omitted from the target to get tags if ‘tags’ is specified for ‘wildignore’.